### PR TITLE
Update the profile name and email values in the maploom.html template.

### DIFF
--- a/maploom/templates/maps/maploom.html
+++ b/maploom/templates/maps/maploom.html
@@ -16,8 +16,8 @@
  config =  {
        authStatus: {% if user.is_authenticated %} 200{% else %} 401{% endif %},
         username: {% if user.is_authenticated %} "{{ user.username }}" {% else %} undefined {% endif %},
-        userprofilename: {% if user.is_authenticated %} "{{ user.profile.name }}" {% else %} undefined {% endif %},
-        userprofileemail: {% if user.is_authenticated %} "{{ user.profile.email }}" {% else %} undefined {% endif %},
+        userprofilename: {% if user.is_authenticated %} "{{ user.get_full_name }}" {% else %} undefined {% endif %},
+        userprofileemail: {% if user.is_authenticated %} "{{ user.email }}" {% else %} undefined {% endif %},
         currentLanguage: "{{language|default:'en'}}",
         proxy: '{{ PROXY_URL }}',
         {% if MF_PRINT_ENABLED %}


### PR DESCRIPTION
Because GeoNode now uses a custom user model, references to the user's name and email address no longer go through a related "profile" table and are directly accessible on the user object.

Without this, the commit author always shows up as **Anonymous**.
